### PR TITLE
Set directory name for cache.pickle file

### DIFF
--- a/custom_components/virgintivo/media_player.py
+++ b/custom_components/virgintivo/media_player.py
@@ -964,8 +964,11 @@ class ChannelListing:
 
 def get_channel_listings(config):
     from bs4 import BeautifulSoup
-
-    cache_file = 'virgin_tivo.pickle'
+    from homeassistant.config import get_default_config_dir
+    import os
+    
+    cfg_dir = get_default_config_dir()
+    cache_file = os.path.join(cfg_dir, 'virgin_tivo.pickle')
 
     def contains(this_cell, this_string):
         if this_string in this_cell:


### PR DESCRIPTION
The file `cache.pickle` could not be created, as it was trying to write to '`/`' in my configuration (Python virtual environment).
This places it inside the configuration directory, where there should be write permissions.