### PR TITLE
Added version info to manifest

### DIFF
--- a/custom_components/virgintivo/manifest.json
+++ b/custom_components/virgintivo/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://github.com/bertbert72/HomeAssistant_VirginTivo/blob/master/README.md",
   "dependencies": [],
   "codeowners": ["@bertbert72"],
-  "requirements": []
+  "requirements": [],
+  "version": "0.0.0"
 }


### PR DESCRIPTION
As detailed in [here](https://www.home-assistant.io/blog/2021/03/03/release-20213/#read-more), a version number will be required in the future for custom components. There is a flurry of others that need this when looking on [Google](https://www.google.co.uk/search?q=ha+version+manifest).